### PR TITLE
Feat capture transfer data

### DIFF
--- a/generate_data.py
+++ b/generate_data.py
@@ -142,33 +142,33 @@ if __name__ == '__main__':
     data_sets = ["01", "04", "06", "08", "10", "12", "14", "16"]
     test_start = datetime.now().strftime("%m-%d-%Y_%Hh%Mm%Ss")
 
-    write_results(transfer_data(tc, args.src_ep_id, args.dest_ep_id, args.src_dir, args.dest_dir, True),
-                  "{}.csv".format(test_start))
+    # write_results(transfer_data(tc, args.src_ep_id, args.dest_ep_id, args.src_dir, args.dest_dir, True),
+    #               "{}.csv".format(test_start))
+    # if args.write_back:
+    #     wdir = args.return_directory or args.src_dir
+    #     write_results(transfer_data(tc, args.dest_ep_id, args.src_ep_id, args.dest_dir, wdir, True),
+    #                   "{}.csv".format(test_start))
+
+    for set in data_sets:
+        write_results(transfer_data(tc, args.src_ep_id, args.dest_ep_id, '/datasets/ds{}'.format(set),
+                      '/rstore/share/TEST_TRANSFER/ds{}'.format(set), True), "{}.csv".format(test_start))
+
     if args.write_back:
-        wdir = args.return_directory or args.src_dir
-        write_results(transfer_data(tc, args.dest_ep_id, args.src_ep_id, args.dest_dir, wdir, True),
-                      "{}.csv".format(test_start))
-        print("Write Back: " + wdir)
+        for set in data_sets:
+            write_results(transfer_data(tc, args.dest_ep_id, args.src_ep_id,
+                                        '/rstore/share/TEST_TRANSFER/ds{}'.format(set), '/perftest/uab_rc/ds{}'.format(set),
+                                        True), "{}.csv".format(test_start))
 
-    # for set in data_sets:
-    #     write_results(transfer_data(tc, args.src_ep_id, args.dest_ep_id, '/datasets/ds{}'.format(set),
-    #                   '/scratch/mmoo97/TEST_TRANSFER/ds{}'.format(set), True), "{}.csv".format(test_start))
+    # if args.clean:
+    #     ddata = globus_sdk.DeleteData(tc, args.dest_ep_id, recursive=True,
+    #                                   label="Delete {}".format(args.dest_dir.split("/")[-1]))
     #
-    # for set in data_sets:
-    #     write_results(transfer_data(tc, args.dest_ep_id, args.src_ep_id,
-    #                                 '/scratch/mmoo97/TEST_TRANSFER/ds{}'.format(set), '/perftest/uab_rc/ds{}'.format(set),
-    #                                 True), "{}.csv".format(test_start))
-
-    if args.clean:
-        ddata = globus_sdk.DeleteData(tc, args.dest_ep_id, recursive=True,
-                                      label="Delete {}".format(args.dest_dir.split("/")[-1]))
-
-        ddata.add_item(args.dest_dir)
-        tc.submit_delete(ddata)
-
-        if args.write_back:
-            ddir = args.return_directory or args.src_dir
-            ddata2 = globus_sdk.DeleteData(tc, args.src_ep_id, recursive=True,
-                                          label="Delete {}".format(args.src_dir.split("/")[-1]))
-            ddata2.add_item(ddir)
-            tc.submit_delete(ddata2)
+    #     ddata.add_item(args.dest_dir)
+    #     tc.submit_delete(ddata)
+    #
+    #     if args.write_back:
+    #         ddir = args.return_directory or args.src_dir
+    #         ddata2 = globus_sdk.DeleteData(tc, args.src_ep_id, recursive=True,
+    #                                       label="Delete {}".format(args.src_dir.split("/")[-1]))
+    #         ddata2.add_item(ddir)
+    #         tc.submit_delete(ddata2)

--- a/generate_data.py
+++ b/generate_data.py
@@ -14,8 +14,13 @@ def get_args():
     parser.add_argument('dest_ep_id', type=str, help='The Endpoint ID of the destination endpoint.')
     parser.add_argument('src_dir', type=str, help='The desired directory from the source endpoint.')
     parser.add_argument('dest_dir', type=str, help='The desired directory from the destination endpoint.')
-    parser.add_argument('-r, --refresh-token', dest='refresh_token', type=str,
+    parser.add_argument('-t, --refresh-token', dest='refresh token', type=str,
                         help='The resource token for Globus Authentication.')
+    parser.add_argument('-r', dest='Return Directory', type=str,
+                        help='The directory to write to if destination write is specified')
+    parser.add_argument('-w', dest='Write back', action='store_true',
+                        help='Write data written to the destination directory back to the source directory.')
+    parser.add_argument('-c', dest='clean', action='store_true', help='Use to delete/clean the transferred files post transfer.')
 
     return parser.parse_args()
 
@@ -138,11 +143,16 @@ if __name__ == '__main__':
     data_sets = ["01", "04", "06", "08", "10", "12", "14", "16"]
     test_start = datetime.now().strftime("%m-%d-%Y_%Hh%Mm%Ss")
 
-    for set in data_sets:
-        write_results(transfer_data(tc, args.src_ep_id, args.dest_ep_id, '/datasets/ds{}'.format(set),
-                      '/scratch/mmoo97/TEST_TRANSFER/ds{}'.format(set), True), "{}.csv".format(test_start))
+    # for set in data_sets:
+    #     write_results(transfer_data(tc, args.src_ep_id, args.dest_ep_id, '/datasets/ds{}'.format(set),
+    #                   '/scratch/mmoo97/TEST_TRANSFER/ds{}'.format(set), True), "{}.csv".format(test_start))
+    #
+    # for set in data_sets:
+    #     write_results(transfer_data(tc, args.dest_ep_id, args.src_ep_id,
+    #                                 '/scratch/mmoo97/TEST_TRANSFER/ds{}'.format(set), '/perftest/uab_rc/ds{}'.format(set),
+    #                                 True), "{}.csv".format(test_start))
 
-    for set in data_sets:
-        write_results(transfer_data(tc, args.dest_ep_id, args.src_ep_id,
-                                    '/scratch/mmoo97/TEST_TRANSFER/ds{}'.format(set), '/perftest/uab_rc/ds{}'.format(set),
-                                    True), "{}.csv".format(test_start))
+    if args.clean:
+        ddata = globus_sdk.DeleteData(tc, args.dest_ep_id, recursive=True)
+        ddata.add_item(args.dest_dir)
+

--- a/generate_data.py
+++ b/generate_data.py
@@ -135,4 +135,13 @@ if __name__ == '__main__':
     tc = globus_sdk.TransferClient(authorizer=authorizer)
 
     # Todo: Make it so that the elapsed time can be created outside of the progress bar context.
-    print(transfer_data(tc, args.src_ep_id, args.dest_ep_id, args.src_dir, args.dest_dir, True))
+    # print(transfer_data(tc, args.src_ep_id, args.dest_ep_id, args.src_dir, args.dest_dir, True))
+
+    # transfer_data(tc, args.src_ep_id, args.dest_ep_id, args.src_dir, args.dest_dir)
+    data_sets = [1, 4, 6, 8, 10, 12, 14, 16]
+    for set in data_sets:
+        set = str(set)
+        if len(set) < 2:
+            set = '0' + set
+        write_results(transfer_data(tc, args.src_ep_id, args.dest_ep_id, '/datasets/ds{}'.format(set),
+                      '/data/user/mmoo97/TEST_TRANSFER/ds{}'.format(set), True), "test.csv")

--- a/generate_data.py
+++ b/generate_data.py
@@ -3,6 +3,7 @@ import sys
 import argparse
 from time import sleep
 import progressbar
+import csv
 
 
 def get_args():
@@ -89,7 +90,8 @@ def transfer_data(tc, src_id, dest_id, src_dir, dest_dir, output):
                     # Todo: Make it so that the elapsed time can be created outside of the progress bar context.
                     "elapsed": str(bar.data()['time_elapsed']),
                     "speed": str(round(task["effective_bytes_per_second"]/(1024*1024), 2)),
-                    "src_ep_id": src_id, "dest_ep_id": dest_id,
+                    "src_ep_id": src_id,
+                    "dest_ep_id": dest_id,
                     "task_id": transfer_result["task_id"]}
 
         elif task["status"] == "ACTIVE":
@@ -105,8 +107,25 @@ def transfer_data(tc, src_id, dest_id, src_dir, dest_dir, output):
             exit(-1)
 
 
-def write_results():
-    pass
+def write_results(data_dict, filename):
+    with open(filename, 'r+', newline='') as file:
+        writer = csv.writer(file)
+        count = 0
+        read = csv.reader(file, delimiter=",")
+        for line in read:
+            count += 1
+
+        if count == 0:
+            writer.writerow(["Dataset", "Start", "End", "Elapsed", "Speed", "Source EP ID", "Dest. EP ID", "Task ID"])
+
+        writer.writerow([data_dict["dataset"],
+                    data_dict["start"],
+                    data_dict["end"],
+                    data_dict["elapsed"],
+                    data_dict["speed"],
+                    data_dict["src_ep_id"],
+                    data_dict["dest_ep_id"],
+                    data_dict["task_id"]])
 
 
 if __name__ == '__main__':

--- a/generate_data.py
+++ b/generate_data.py
@@ -110,8 +110,6 @@ def transfer_data(tc, src_id, dest_id, src_dir, dest_dir, output):
 def write_results(data_dict, filename):
     with open(filename, 'a+', newline='') as file:
         writer = csv.writer(file)
-        count = 0
-        read = csv.reader(file, delimiter=",")
 
         if file.tell() == 0:
             writer.writerow(["Dataset", "Start", "End", "Elapsed", "Speed", "Source EP ID", "Dest. EP ID", "Task ID"])
@@ -137,19 +135,14 @@ if __name__ == '__main__':
 
     # write_results(transfer_data(tc, args.src_ep_id, args.dest_ep_id, args.src_dir, args.dest_dir, True), "test.csv")
 
-    data_sets = [1, 4, 6, 8, 10, 12, 14, 16]
+    data_sets = ["01", "04", "06", "08", "10", "12", "14", "16"]
     test_start = datetime.now().strftime("%m-%d-%Y_%Hh%Mm%Ss")
+
     for set in data_sets:
-        set = str(set)
-        if len(set) < 2:
-            set = '0' + set
         write_results(transfer_data(tc, args.src_ep_id, args.dest_ep_id, '/datasets/ds{}'.format(set),
                       '/scratch/mmoo97/TEST_TRANSFER/ds{}'.format(set), True), "{}.csv".format(test_start))
 
     for set in data_sets:
-        set = str(set)
-        if len(set) < 2:
-            set = '0' + set
         write_results(transfer_data(tc, args.dest_ep_id, args.src_ep_id,
                                     '/scratch/mmoo97/TEST_TRANSFER/ds{}'.format(set), '/perftest/uab_rc/ds{}'.format(set),
                                     True), "{}.csv".format(test_start))


### PR DESCRIPTION
- Add integration of command line arguments and flags
- Add ability to remove the transferred datasets from the destination endpoint and the source endpoint write directory
- Ability to authenticate using the webauth and get a refresh token for future use of the script.
- Ability to use a refresh token and not having to use a link to the browser for authentication.
- Limited functionality to submit all dataset transfer tasks at once in one batch (output for batch transfers not yet supported)
- Outputs transfer results to a .csv with the initialization data and time as the filename (format: "%m-%d-%Y_%Hh%Mm%Ss").
- Remove support for the vars.py file.
- Overall antiquate the DTN Jupyter Notebook for the purpose of data collection.